### PR TITLE
Add watchlist species notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Push bird detection notifications from [BirdNet Go](https://github.com/tphakala/
 ## Features
 
 - **New Species Alerts**: Instant notifications when a never-before-seen species is detected (first ever, first of year, or first of season)
+- **Watchlist Notifications**: Always get notified when specific species are detected, regardless of other filters — with configurable cooldown to prevent spam
 - **Scheduled Summaries**: Configurable daily, hourly, weekly, or custom interval reports
 - **Bird Images**: Embeds include species photos from BirdNet Go's Wikimedia cache
 - **Fully Configurable**: YAML config with per-summary webhooks, confidence thresholds, species filters, and more
@@ -53,6 +54,13 @@ new_species:
     first_ever: true      # Never seen before
     first_of_year: true   # First of calendar year
     first_of_season: false
+
+
+# Watchlist - always get notified about specific species
+watchlist:
+  enabled: true
+  species: ["Pileated Woodpecker", "Barred Owl"]
+  cooldown_minutes: 60  # Suppress repeats within 1 hour
 
 # Scheduled summaries (add as many as you want)
 summaries:
@@ -103,6 +111,17 @@ birdnet:
     username: "birdnet"
     password: "your_password"
 ```
+
+
+### Watchlist
+
+The watchlist lets you always receive notifications for specific species, even if they have been seen before. This is useful for rare visitors or personal favorites.
+
+- Species are matched by common name (case-insensitive)
+- A configurable cooldown (default: 1 hour) prevents repeat alerts for the same species
+- If a watchlisted species is also a **new species** (first ever, first of year, etc.), you get **one combined alert** with both the watchlist styling and the new-species badge — no duplicates
+- New species detections bypass the watchlist cooldown (first sightings are always worth knowing about)
+- Watchlist alerts use a distinct orange embed style so they stand out in your Discord channel
 
 ## Usage
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -29,6 +29,16 @@ new_species:
     first_of_year: true  # First sighting this calendar year
     first_of_season: false  # First sighting this season (spring/summer/fall/winter)
 
+
+# WATCHLIST - always-notify species regardless of other settings
+# When a watchlisted species is detected, you get an alert even if it has been seen before.
+# If it is also a new species (first ever, first of year, etc.), you get ONE combined alert.
+watchlist:
+  enabled: false  # Set to true to enable watchlist notifications
+  species: []  # List species by common name: ["Pileated Woodpecker", "Barred Owl"]
+  cooldown_minutes: 60  # Suppress repeat alerts for same species within this window
+  webhook_url: null  # Optional: separate webhook (null = use default)
+
 # Scheduled summary reports
 # You can define as many summaries as you want with different schedules and lookback periods
 summaries:

--- a/robo_birder/config.py
+++ b/robo_birder/config.py
@@ -121,3 +121,32 @@ def get_season_start_date(config: dict[str, Any], season: str, year: int) -> "da
     start_day = season_cfg.get("start_day", defaults[season][1])
 
     return datetime(year, start_month, start_day)
+
+
+def is_watchlist_enabled(config: dict[str, Any]) -> bool:
+    """Check if watchlist notifications are enabled.
+
+    Args:
+        config: Configuration dictionary.
+
+    Returns:
+        True if watchlist is enabled and has species.
+    """
+    watchlist = config.get("watchlist", {})
+    return watchlist.get("enabled", False) and bool(watchlist.get("species", []))
+
+
+def get_watchlist_species(config: dict[str, Any]) -> set[str]:
+    """Get the set of watchlisted species names (lowercase for matching).
+
+    Args:
+        config: Configuration dictionary.
+
+    Returns:
+        Set of lowercase species names, or empty set if disabled.
+    """
+    if not is_watchlist_enabled(config):
+        return set()
+
+    species_list = config.get("watchlist", {}).get("species", [])
+    return {s.lower() for s in species_list}

--- a/robo_birder/config.py
+++ b/robo_birder/config.py
@@ -149,4 +149,10 @@ def get_watchlist_species(config: dict[str, Any]) -> set[str]:
         return set()
 
     species_list = config.get("watchlist", {}).get("species", [])
+    if not isinstance(species_list, list):
+        import logging
+        logging.getLogger(__name__).warning(
+            "watchlist.species should be a list, got %s", type(species_list).__name__
+        )
+        return set()
     return {s.lower() for s in species_list}

--- a/robo_birder/discord.py
+++ b/robo_birder/discord.py
@@ -16,6 +16,7 @@ COLOR_NEW_SPECIES = 0xFFD700  # Gold
 COLOR_DETECTION = 0x3498DB  # Blue
 COLOR_SUMMARY = 0x2ECC71  # Green
 COLOR_ERROR = 0xE74C3C  # Red
+COLOR_WATCHLIST = 0xFF8C00  # Orange/amber
 
 
 def send_webhook(webhook_url: str, payload: dict[str, Any]) -> bool:
@@ -272,6 +273,82 @@ def send_summary(
                 "inline": False,
             }
         ]
+
+    payload = {"embeds": [embed]}
+
+    return send_webhook(webhook_url, payload)
+
+
+
+def send_watchlist_alert(
+    webhook_url: str,
+    detection: Detection,
+    image_url: str | None = None,
+    birdnet_base_url: str = "http://localhost:8080",
+    is_new_species: bool = False,
+    new_reason: str | None = None,
+) -> bool:
+    """Send a watchlist species alert to Discord.
+
+    Args:
+        webhook_url: Discord webhook URL.
+        detection: Detection record.
+        image_url: Optional bird image URL.
+        birdnet_base_url: Base URL for BirdNet Go web UI.
+        is_new_species: Whether this is also a new species detection.
+        new_reason: Reason string if new species (e.g., "First ever sighting!").
+
+    Returns:
+        True if successful.
+    """
+    try:
+        time_str = detection.begin_time.strftime("%-I:%M %p")
+    except ValueError:
+        time_str = detection.begin_time.strftime("%I:%M %p").lstrip("0")
+
+    if is_new_species:
+        title = f"WATCHLIST + NEW: {detection.common_name}"
+    else:
+        title = f"WATCHLIST: {detection.common_name}"
+
+    fields = [
+        {
+            "name": detection.common_name,
+            "value": f"*{detection.scientific_name}*",
+            "inline": False,
+        },
+        {
+            "name": "Confidence",
+            "value": f"{detection.confidence:.0%}",
+            "inline": True,
+        },
+        {
+            "name": "Time",
+            "value": time_str,
+            "inline": True,
+        },
+    ]
+
+    if is_new_species and new_reason:
+        fields.append(
+            {
+                "name": "New Species",
+                "value": f"**{new_reason}**",
+                "inline": False,
+            }
+        )
+
+    embed = {
+        "title": title,
+        "color": COLOR_WATCHLIST,
+        "fields": fields,
+        "footer": {"text": "Robo-Birder | Watchlist"},
+        "timestamp": detection.begin_time.isoformat(),
+        "url": f"{birdnet_base_url}/ui/detections/{detection.id}",
+    }
+
+    if image_url:
+        embed["thumbnail"] = {"url": image_url}
 
     payload = {"embeds": [embed]}
 

--- a/robo_birder/notify.py
+++ b/robo_birder/notify.py
@@ -2,13 +2,12 @@
 
 import json
 import logging
-import os
 import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from .config import get_current_season, get_season_start_date, get_webhook_url
+from .config import get_current_season, get_season_start_date, get_watchlist_species, get_webhook_url
 from .database import (
     Detection,
     get_bird_image_url,
@@ -157,7 +156,6 @@ def check_new_species(
 
 
 
-
 def check_watchlist(detection: Detection, config: dict[str, Any]) -> bool:
     """Check if a detection is for a watchlisted species.
 
@@ -168,8 +166,6 @@ def check_watchlist(detection: Detection, config: dict[str, Any]) -> bool:
     Returns:
         True if species is on the watchlist.
     """
-    from .config import get_watchlist_species
-
     watchlist = get_watchlist_species(config)
     if not watchlist:
         return False
@@ -274,6 +270,10 @@ def handle_detection(detection: Detection, config: dict[str, Any]) -> bool:
                 new_reason=new_reason,
             ):
                 set_cooldown(watchlist_cooldown_key)
+                # Also set the new-species cooldown so check_new_species
+                # won't re-flag this species as "new" on the next detection.
+                # After this cooldown expires, subsequent watchlist hits show
+                # as watchlist-only (without the new-species badge).
                 if is_new:
                     set_cooldown(detection.scientific_name)
                 return True

--- a/robo_birder/notify.py
+++ b/robo_birder/notify.py
@@ -20,7 +20,7 @@ from .database import (
     species_seen_since,
     species_seen_this_year,
 )
-from .discord import send_detection_alert, send_new_species_alert
+from .discord import send_detection_alert, send_new_species_alert, send_watchlist_alert
 
 logger = logging.getLogger(__name__)
 
@@ -156,6 +156,27 @@ def check_new_species(
     return False, None
 
 
+
+
+def check_watchlist(detection: Detection, config: dict[str, Any]) -> bool:
+    """Check if a detection is for a watchlisted species.
+
+    Args:
+        detection: Detection record.
+        config: Configuration dictionary.
+
+    Returns:
+        True if species is on the watchlist.
+    """
+    from .config import get_watchlist_species
+
+    watchlist = get_watchlist_species(config)
+    if not watchlist:
+        return False
+
+    return detection.common_name.lower() in watchlist
+
+
 def should_notify_realtime(
     detection: Detection, config: dict[str, Any]
 ) -> bool:
@@ -203,6 +224,12 @@ def should_notify_realtime(
 def handle_detection(detection: Detection, config: dict[str, Any]) -> bool:
     """Handle a new detection and send appropriate notifications.
 
+    Priority order:
+    1. Watchlisted + new species -> one watchlist-styled alert with new-species badge
+    2. Watchlisted only -> watchlist alert (subject to watchlist cooldown)
+    3. New species only -> existing new species alert
+    4. Realtime enabled -> existing detection alert
+
     Args:
         detection: Detection record.
         config: Configuration dictionary.
@@ -216,40 +243,65 @@ def handle_detection(detection: Detection, config: dict[str, Any]) -> bool:
     # Get bird image
     image_url = get_bird_image_url(db_config, detection.scientific_name)
 
-    notification_sent = False
+    # Check both conditions upfront
+    is_watchlisted = check_watchlist(detection, config)
+    is_new, new_reason = check_new_species(detection, config, db_config)
 
-    # Check for new species first (higher priority)
-    is_new, reason = check_new_species(detection, config, db_config)
+    # Priority 1 & 2: Watchlisted species
+    if is_watchlisted:
+        watchlist_config = config.get("watchlist", {})
+        webhook_url = get_webhook_url(config, watchlist_config.get("webhook_url"))
+        cooldown_minutes = watchlist_config.get("cooldown_minutes", 60)
+        watchlist_cooldown_key = f"watchlist:{detection.scientific_name}"
 
-    if is_new:
+        # New species bypasses watchlist cooldown
+        if not is_new and is_on_cooldown(watchlist_cooldown_key, cooldown_minutes):
+            logger.debug(
+                f"Watchlist species {detection.common_name} on cooldown, skipping"
+            )
+        else:
+            logger.info(
+                f"Watchlist species detected: {detection.common_name}"
+                + (f" - {new_reason}" if is_new else "")
+            )
+
+            if send_watchlist_alert(
+                webhook_url,
+                detection,
+                image_url=image_url,
+                birdnet_base_url=birdnet_base_url,
+                is_new_species=is_new,
+                new_reason=new_reason,
+            ):
+                set_cooldown(watchlist_cooldown_key)
+                if is_new:
+                    set_cooldown(detection.scientific_name)
+                return True
+
+    # Priority 3: New species (not watchlisted)
+    elif is_new:
         new_species_config = config.get("new_species", {})
-        webhook_url = get_webhook_url(
-            config, new_species_config.get("webhook_url")
-        )
+        webhook_url = get_webhook_url(config, new_species_config.get("webhook_url"))
 
-        logger.info(
-            f"New species detected: {detection.common_name} - {reason}"
-        )
+        logger.info(f"New species detected: {detection.common_name} - {new_reason}")
 
         if send_new_species_alert(
-            webhook_url, detection, reason, image_url, birdnet_base_url
+            webhook_url, detection, new_reason, image_url, birdnet_base_url
         ):
-            notification_sent = True
             set_cooldown(detection.scientific_name)
+            return True
 
-    # Check for realtime notification (only if not already notified as new species)
+    # Priority 4: Realtime notification
     elif should_notify_realtime(detection, config):
         webhook_url = get_webhook_url(config)
 
         logger.info(f"Detection alert: {detection.common_name}")
 
-        if send_detection_alert(
-            webhook_url, detection, image_url, birdnet_base_url
-        ):
-            notification_sent = True
+        if send_detection_alert(webhook_url, detection, image_url, birdnet_base_url):
             set_cooldown(detection.scientific_name)
+            return True
 
-    return notification_sent
+    return False
 
 
 def handle_detection_by_id(detection_id: int, config: dict[str, Any]) -> bool:

--- a/robo_birder/notify.py
+++ b/robo_birder/notify.py
@@ -250,7 +250,10 @@ def handle_detection(detection: Detection, config: dict[str, Any]) -> bool:
         cooldown_minutes = watchlist_config.get("cooldown_minutes", 60)
         watchlist_cooldown_key = f"watchlist:{detection.scientific_name}"
 
-        # New species bypasses watchlist cooldown
+        # New species bypasses watchlist cooldown.
+        # Note: when a watchlisted species is on cooldown, it also suppresses
+        # realtime notifications for that species. This is intentional — the
+        # user already received a watchlist alert recently.
         if not is_new and is_on_cooldown(watchlist_cooldown_key, cooldown_minutes):
             logger.debug(
                 f"Watchlist species {detection.common_name} on cooldown, skipping"
@@ -277,6 +280,23 @@ def handle_detection(detection: Detection, config: dict[str, Any]) -> bool:
                 if is_new:
                     set_cooldown(detection.scientific_name)
                 return True
+            elif is_new:
+                # Watchlist alert failed but this is a new species —
+                # fall back to the regular new-species alert path
+                logger.warning(
+                    "Watchlist alert failed for new species %s, "
+                    "falling back to new-species alert",
+                    detection.common_name,
+                )
+                new_species_config = config.get("new_species", {})
+                fallback_url = get_webhook_url(
+                    config, new_species_config.get("webhook_url")
+                )
+                if send_new_species_alert(
+                    fallback_url, detection, new_reason, image_url, birdnet_base_url
+                ):
+                    set_cooldown(detection.scientific_name)
+                    return True
 
     # Priority 3: New species (not watchlisted)
     elif is_new:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,83 @@
+"""Shared test fixtures for robo-birder tests."""
+
+import pytest
+from datetime import datetime
+from robo_birder.database import Detection
+
+
+@pytest.fixture
+def sample_detection():
+    """A standard detection for testing."""
+    return Detection(
+        id=42,
+        date="2026-04-16",
+        time="14:30:00",
+        begin_time=datetime(2026, 4, 16, 14, 30, 0),
+        scientific_name="Dryocopus pileatus",
+        common_name="Pileated Woodpecker",
+        confidence=0.85,
+        clip_name="clip_042.wav",
+        species_code="pilwoo",
+    )
+
+
+@pytest.fixture
+def sample_detection_unlisted():
+    """A detection for a species NOT on the watchlist."""
+    return Detection(
+        id=43,
+        date="2026-04-16",
+        time="14:35:00",
+        begin_time=datetime(2026, 4, 16, 14, 35, 0),
+        scientific_name="Cardinalis cardinalis",
+        common_name="Northern Cardinal",
+        confidence=0.92,
+        clip_name="clip_043.wav",
+        species_code="norcar",
+    )
+
+
+@pytest.fixture
+def watchlist_config():
+    """Config with watchlist enabled."""
+    return {
+        "discord": {"webhook_url": "https://discord.com/api/webhooks/test/test"},
+        "birdnet": {
+            "db_type": "sqlite",
+            "db_path": ":memory:",
+            "base_url": "http://localhost:8080",
+        },
+        "watchlist": {
+            "enabled": True,
+            "species": ["Pileated Woodpecker", "Barred Owl", "Eastern Bluebird"],
+            "cooldown_minutes": 60,
+            "webhook_url": None,
+        },
+        "new_species": {
+            "enabled": True,
+            "min_confidence": 0.5,
+            "cooldown_minutes": 5,
+            "notify_on": {
+                "first_ever": True,
+                "first_of_year": True,
+                "first_of_season": False,
+            },
+        },
+        "realtime": {"enabled": False},
+    }
+
+
+@pytest.fixture
+def watchlist_config_disabled():
+    """Config with watchlist disabled."""
+    return {
+        "discord": {"webhook_url": "https://discord.com/api/webhooks/test/test"},
+        "birdnet": {
+            "db_type": "sqlite",
+            "db_path": ":memory:",
+            "base_url": "http://localhost:8080",
+        },
+        "watchlist": {"enabled": False, "species": [], "cooldown_minutes": 60},
+        "new_species": {"enabled": False},
+        "realtime": {"enabled": False},
+    }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,3 +30,16 @@ def test_is_watchlist_enabled_false(watchlist_config_disabled):
 def test_is_watchlist_enabled_missing_section():
     config = {"discord": {"webhook_url": "test"}}
     assert is_watchlist_enabled(config) is False
+
+
+def test_get_watchlist_species_string_instead_of_list():
+    """String species value (common YAML mistake) returns empty set."""
+    config = {
+        "watchlist": {
+            "enabled": True,
+            "species": "Pileated Woodpecker",  # string, not list
+        }
+    }
+    from robo_birder.config import get_watchlist_species
+    result = get_watchlist_species(config)
+    assert result == set()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,32 @@
+"""Tests for watchlist configuration parsing."""
+
+from robo_birder.config import get_watchlist_species, is_watchlist_enabled
+
+
+def test_get_watchlist_species_returns_lowercase_set(watchlist_config):
+    result = get_watchlist_species(watchlist_config)
+    assert result == {"pileated woodpecker", "barred owl", "eastern bluebird"}
+
+
+def test_get_watchlist_species_empty_when_disabled(watchlist_config_disabled):
+    result = get_watchlist_species(watchlist_config_disabled)
+    assert result == set()
+
+
+def test_get_watchlist_species_empty_when_missing():
+    config = {"discord": {"webhook_url": "test"}}
+    result = get_watchlist_species(config)
+    assert result == set()
+
+
+def test_is_watchlist_enabled_true(watchlist_config):
+    assert is_watchlist_enabled(watchlist_config) is True
+
+
+def test_is_watchlist_enabled_false(watchlist_config_disabled):
+    assert is_watchlist_enabled(watchlist_config_disabled) is False
+
+
+def test_is_watchlist_enabled_missing_section():
+    config = {"discord": {"webhook_url": "test"}}
+    assert is_watchlist_enabled(config) is False

--- a/tests/test_discord.py
+++ b/tests/test_discord.py
@@ -1,0 +1,69 @@
+"""Tests for watchlist Discord embed formatting."""
+
+from unittest.mock import patch
+from robo_birder.discord import send_watchlist_alert, COLOR_WATCHLIST
+
+
+def test_watchlist_alert_basic(sample_detection):
+    """Watchlist alert has correct color and title."""
+    with patch("robo_birder.discord.send_webhook", return_value=True) as mock:
+        result = send_watchlist_alert(
+            "https://discord.com/api/webhooks/test/test",
+            sample_detection,
+            image_url="https://example.com/bird.jpg",
+            birdnet_base_url="http://localhost:8080",
+        )
+
+    assert result is True
+    payload = mock.call_args[0][1]
+    embed = payload["embeds"][0]
+    assert embed["color"] == COLOR_WATCHLIST
+    assert "WATCHLIST" in embed["title"]
+    assert "Pileated Woodpecker" in embed["title"]
+    assert "NEW" not in embed["title"]
+
+
+def test_watchlist_alert_with_new_species(sample_detection):
+    """Watchlist + new species shows combined title and reason."""
+    with patch("robo_birder.discord.send_webhook", return_value=True) as mock:
+        result = send_watchlist_alert(
+            "https://discord.com/api/webhooks/test/test",
+            sample_detection,
+            image_url=None,
+            birdnet_base_url="http://localhost:8080",
+            is_new_species=True,
+            new_reason="First ever sighting!",
+        )
+
+    assert result is True
+    payload = mock.call_args[0][1]
+    embed = payload["embeds"][0]
+    assert "WATCHLIST" in embed["title"]
+    assert "NEW" in embed["title"]
+
+    # Check that the new species reason appears in fields
+    field_values = " ".join(f["value"] for f in embed["fields"])
+    assert "First ever sighting!" in field_values
+
+
+def test_watchlist_alert_has_detection_link(sample_detection):
+    """Watchlist alert includes link to BirdNet Go detection."""
+    with patch("robo_birder.discord.send_webhook", return_value=True) as mock:
+        send_watchlist_alert(
+            "https://discord.com/api/webhooks/test/test",
+            sample_detection,
+            birdnet_base_url="http://localhost:8080",
+        )
+
+    payload = mock.call_args[0][1]
+    embed = payload["embeds"][0]
+    assert embed["url"] == "http://localhost:8080/ui/detections/42"
+
+
+def test_watchlist_color_is_distinct():
+    """Watchlist color is distinct from other alert colors."""
+    from robo_birder.discord import COLOR_NEW_SPECIES, COLOR_DETECTION, COLOR_SUMMARY
+
+    assert COLOR_WATCHLIST != COLOR_NEW_SPECIES
+    assert COLOR_WATCHLIST != COLOR_DETECTION
+    assert COLOR_WATCHLIST != COLOR_SUMMARY

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,0 +1,133 @@
+"""Tests for watchlist notification logic."""
+
+from unittest.mock import patch
+from robo_birder.notify import (
+    check_watchlist,
+    is_on_cooldown,
+    set_cooldown,
+    handle_detection,
+)
+
+
+class TestCheckWatchlist:
+    def test_watchlisted_species_detected(self, sample_detection, watchlist_config):
+        """Pileated Woodpecker is on the watchlist - should return True."""
+        assert check_watchlist(sample_detection, watchlist_config) is True
+
+    def test_unlisted_species_not_detected(self, sample_detection_unlisted, watchlist_config):
+        """Northern Cardinal is NOT on the watchlist - should return False."""
+        assert check_watchlist(sample_detection_unlisted, watchlist_config) is False
+
+    def test_case_insensitive_match(self, sample_detection, watchlist_config):
+        """Match should be case-insensitive."""
+        watchlist_config["watchlist"]["species"] = ["pileated woodpecker"]
+        assert check_watchlist(sample_detection, watchlist_config) is True
+
+    def test_disabled_watchlist(self, sample_detection, watchlist_config_disabled):
+        """Disabled watchlist returns False."""
+        assert check_watchlist(sample_detection, watchlist_config_disabled) is False
+
+
+class TestWatchlistCooldown:
+    def test_not_on_cooldown_initially(self, tmp_path):
+        """Species not on cooldown if never notified."""
+        cooldown_file = tmp_path / "cooldowns.json"
+        with patch("robo_birder.notify.COOLDOWN_FILE", cooldown_file):
+            assert is_on_cooldown("watchlist:Dryocopus pileatus", 60) is False
+
+    def test_on_cooldown_after_set(self, tmp_path):
+        """Species is on cooldown after set_cooldown."""
+        cooldown_file = tmp_path / "cooldowns.json"
+        with patch("robo_birder.notify.COOLDOWN_FILE", cooldown_file):
+            set_cooldown("watchlist:Dryocopus pileatus")
+            assert is_on_cooldown("watchlist:Dryocopus pileatus", 60) is True
+
+    def test_separate_from_realtime_cooldown(self, tmp_path):
+        """Watchlist cooldown key is separate from realtime cooldown key."""
+        cooldown_file = tmp_path / "cooldowns.json"
+        with patch("robo_birder.notify.COOLDOWN_FILE", cooldown_file):
+            set_cooldown("Dryocopus pileatus")  # realtime key
+            assert is_on_cooldown("watchlist:Dryocopus pileatus", 60) is False
+
+
+class TestHandleDetectionWatchlist:
+    @patch("robo_birder.notify.get_bird_image_url", return_value="https://example.com/bird.jpg")
+    @patch("robo_birder.notify.send_watchlist_alert", return_value=True)
+    @patch("robo_birder.notify.check_new_species", return_value=(False, None))
+    def test_watchlisted_species_sends_watchlist_alert(
+        self, mock_new, mock_watchlist_alert, mock_img, sample_detection, watchlist_config, tmp_path
+    ):
+        """Watchlisted species that is not new sends watchlist alert."""
+        cooldown_file = tmp_path / "cooldowns.json"
+        with patch("robo_birder.notify.COOLDOWN_FILE", cooldown_file):
+            result = handle_detection(sample_detection, watchlist_config)
+
+        assert result is True
+        mock_watchlist_alert.assert_called_once()
+        _, kwargs = mock_watchlist_alert.call_args
+        assert kwargs.get("is_new_species", False) is False
+
+    @patch("robo_birder.notify.get_bird_image_url", return_value="https://example.com/bird.jpg")
+    @patch("robo_birder.notify.send_watchlist_alert", return_value=True)
+    @patch("robo_birder.notify.check_new_species", return_value=(True, "First ever sighting!"))
+    def test_watchlisted_new_species_sends_combined_alert(
+        self, mock_new, mock_watchlist_alert, mock_img, sample_detection, watchlist_config, tmp_path
+    ):
+        """Watchlisted species that IS new sends one combined alert."""
+        cooldown_file = tmp_path / "cooldowns.json"
+        with patch("robo_birder.notify.COOLDOWN_FILE", cooldown_file):
+            result = handle_detection(sample_detection, watchlist_config)
+
+        assert result is True
+        mock_watchlist_alert.assert_called_once()
+        _, kwargs = mock_watchlist_alert.call_args
+        assert kwargs["is_new_species"] is True
+        assert kwargs["new_reason"] == "First ever sighting!"
+
+    @patch("robo_birder.notify.get_bird_image_url", return_value=None)
+    @patch("robo_birder.notify.send_new_species_alert", return_value=True)
+    @patch("robo_birder.notify.check_new_species", return_value=(True, "First ever sighting!"))
+    def test_non_watchlisted_new_species_uses_existing_alert(
+        self, mock_new, mock_new_alert, mock_img, sample_detection_unlisted, watchlist_config, tmp_path
+    ):
+        """Non-watchlisted new species uses the existing new species alert path."""
+        cooldown_file = tmp_path / "cooldowns.json"
+        with patch("robo_birder.notify.COOLDOWN_FILE", cooldown_file):
+            result = handle_detection(sample_detection_unlisted, watchlist_config)
+
+        assert result is True
+        mock_new_alert.assert_called_once()
+
+    @patch("robo_birder.notify.get_bird_image_url", return_value=None)
+    @patch("robo_birder.notify.send_watchlist_alert", return_value=True)
+    @patch("robo_birder.notify.check_new_species", return_value=(False, None))
+    def test_watchlist_cooldown_suppresses_repeat(
+        self, mock_new, mock_watchlist_alert, mock_img, sample_detection, watchlist_config, tmp_path
+    ):
+        """Second watchlist detection within cooldown window is suppressed."""
+        cooldown_file = tmp_path / "cooldowns.json"
+        with patch("robo_birder.notify.COOLDOWN_FILE", cooldown_file):
+            handle_detection(sample_detection, watchlist_config)
+            mock_watchlist_alert.reset_mock()
+
+            result = handle_detection(sample_detection, watchlist_config)
+
+        assert result is False
+        mock_watchlist_alert.assert_not_called()
+
+    @patch("robo_birder.notify.get_bird_image_url", return_value=None)
+    @patch("robo_birder.notify.send_watchlist_alert", return_value=True)
+    @patch("robo_birder.notify.check_new_species", return_value=(True, "First ever sighting!"))
+    def test_new_species_bypasses_watchlist_cooldown(
+        self, mock_new, mock_watchlist_alert, mock_img, sample_detection, watchlist_config, tmp_path
+    ):
+        """New species detection bypasses watchlist cooldown."""
+        cooldown_file = tmp_path / "cooldowns.json"
+        with patch("robo_birder.notify.COOLDOWN_FILE", cooldown_file):
+            # Set cooldown (simulate recent notification)
+            set_cooldown(f"watchlist:{sample_detection.scientific_name}")
+
+            result = handle_detection(sample_detection, watchlist_config)
+
+        assert result is True
+        mock_watchlist_alert.assert_called_once()

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -131,3 +131,63 @@ class TestHandleDetectionWatchlist:
 
         assert result is True
         mock_watchlist_alert.assert_called_once()
+
+
+class TestHandleDetectionEdgeCases:
+    @patch("robo_birder.notify.get_bird_image_url", return_value=None)
+    @patch("robo_birder.notify.send_watchlist_alert", return_value=False)
+    @patch("robo_birder.notify.check_new_species", return_value=(False, None))
+    def test_watchlist_alert_failure_returns_false_no_cooldown(
+        self, mock_new, mock_alert, mock_img, sample_detection, watchlist_config, tmp_path
+    ):
+        """Webhook failure returns False and does not set cooldown."""
+        cooldown_file = tmp_path / "cooldowns.json"
+        with patch("robo_birder.notify.COOLDOWN_FILE", cooldown_file):
+            result = handle_detection(sample_detection, watchlist_config)
+        assert result is False
+
+    @patch("robo_birder.notify.get_bird_image_url", return_value=None)
+    @patch("robo_birder.notify.send_watchlist_alert", return_value=False)
+    @patch("robo_birder.notify.send_new_species_alert", return_value=True)
+    @patch("robo_birder.notify.check_new_species", return_value=(True, "First ever sighting!"))
+    def test_watchlist_failure_falls_back_to_new_species_alert(
+        self, mock_new, mock_new_alert, mock_watchlist_alert, mock_img,
+        sample_detection, watchlist_config, tmp_path
+    ):
+        """If watchlist alert fails for a new species, falls back to new-species alert."""
+        cooldown_file = tmp_path / "cooldowns.json"
+        with patch("robo_birder.notify.COOLDOWN_FILE", cooldown_file):
+            result = handle_detection(sample_detection, watchlist_config)
+        assert result is True
+        mock_new_alert.assert_called_once()
+
+    @patch("robo_birder.notify.get_bird_image_url", return_value=None)
+    @patch("robo_birder.notify.send_detection_alert", return_value=True)
+    @patch("robo_birder.notify.check_new_species", return_value=(False, None))
+    def test_non_watchlisted_non_new_uses_realtime(
+        self, mock_new, mock_realtime_alert, mock_img,
+        sample_detection_unlisted, tmp_path
+    ):
+        """Non-watchlisted, non-new species with realtime enabled uses realtime path."""
+        config = {
+            "discord": {"webhook_url": "https://discord.com/api/webhooks/test/test"},
+            "birdnet": {
+                "db_type": "sqlite",
+                "db_path": ":memory:",
+                "base_url": "http://localhost:8080",
+            },
+            "watchlist": {"enabled": False, "species": []},
+            "new_species": {"enabled": False},
+            "realtime": {
+                "enabled": True,
+                "min_confidence": 0.5,
+                "cooldown_minutes": 5,
+                "species_whitelist": [],
+                "species_blacklist": [],
+            },
+        }
+        cooldown_file = tmp_path / "cooldowns.json"
+        with patch("robo_birder.notify.COOLDOWN_FILE", cooldown_file):
+            result = handle_detection(sample_detection_unlisted, config)
+        assert result is True
+        mock_realtime_alert.assert_called_once()


### PR DESCRIPTION
## Summary
- Adds configurable species watchlist — always get notified when a watchlisted species is detected, regardless of "new species only" filter
- Watchlist alerts use distinct orange/amber embed styling to stand out
- If a watchlisted species is also a new species, one combined alert is sent (no duplicates) with both the watchlist styling and new-species badge
- Configurable cooldown (default 1 hour) prevents spam; new-species detections bypass the cooldown
- Includes 22 tests covering config parsing, embed formatting, and detection flow

## Configuration
```yaml
watchlist:
  enabled: true
  species: ["Pileated Woodpecker", "Barred Owl"]
  cooldown_minutes: 60
  webhook_url: null
```

## Test plan
- [x] Verify config parsing with enabled/disabled/missing watchlist sections
- [x] Verify embed formatting: watchlist-only vs watchlist+new-species combined
- [x] Verify detection priority: watchlisted+new > watchlisted > new > realtime
- [x] Verify cooldown suppresses repeats but new-species bypasses it
- [ ] Manual test with a live BirdNet Go instance (optional)

Closes #1